### PR TITLE
fix(command): add allowed-tools and parameterize hardcoded path in upgrade-patches

### DIFF
--- a/.claude/commands/upgrade-patches.md
+++ b/.claude/commands/upgrade-patches.md
@@ -1,5 +1,7 @@
 ---
 description: Upgrade system prompt patches to the latest Claude Code version
+allowed-tools:
+  - Bash
 ---
 
 Upgrade system prompt patches to the latest Claude Code version.
@@ -10,4 +12,4 @@ Upgrade system prompt patches to the latest Claude Code version.
 4. If not, follow `system-prompt/UPGRADING.md` to upgrade
 5. Always go through the **full** Final Verification Checklist at the bottom of UPGRADING.md - all three build types (npm, native-linux, native-macos) and all tests in the matrix, not just one. Use tmux for interactive tests like `/context`.
 
-**Container:** Use a dedicated `safeclaw-upgrade` container for all upgrade work. Create it with `cd /Users/yk/Desktop/projects/safeclaw && ./scripts/run.sh -s upgrade -n` if it doesn't exist. Do NOT use other safeclaw containers (e.g. community, work) - they may have specific Claude versions pinned for other purposes.
+**Container:** Use a dedicated `safeclaw-upgrade` container for all upgrade work. Create it with `cd $SAFECLAW_DIR && ./scripts/run.sh -s upgrade -n` if it doesn't exist (set `SAFECLAW_DIR` to the path of your local safeclaw checkout). Do NOT use other safeclaw containers (e.g. community, work) - they may have specific Claude versions pinned for other purposes.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Summary

This PR fixes two bugs in `.claude/commands/upgrade-patches.md` identified by an automated NLPM audit:

### Bug 1: Missing `allowed-tools` frontmatter

The command invokes Bash tools (`npm`, `tmux`) but has no `allowed-tools` field in its frontmatter. Without this, Claude Code may prompt for permission on every tool use or fail to execute the steps reliably.

**Fix:** Added `allowed-tools: [Bash]` to the frontmatter.

### Bug 2: Hardcoded absolute path `/Users/yk/Desktop/projects/safeclaw`

The **Container** section contains a hardcoded path specific to the author's machine (`/Users/yk/Desktop/projects/safeclaw`). Any contributor running this command will get a path-not-found error and be unable to create the upgrade container.

**Fix:** Replaced the hardcoded path with `$SAFECLAW_DIR` and added a brief note for users to set the environment variable to their local safeclaw checkout.

## Test plan

- [ ] Verify the frontmatter parses correctly (YAML linting or `claude command list`)
- [ ] Confirm the Container step no longer references a machine-specific path