### PR TITLE
fix(security): pin cc-safe to version 0.1.13 in setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -134,12 +134,12 @@ elif command -v cc-safe &> /dev/null; then
     echo -e "${GREEN}[Already installed]${NC} cc-safe"
 else
     echo "[Installing] cc-safe..."
-    if npm install -g cc-safe 2>/dev/null; then
+    if npm install -g cc-safe@0.1.13 2>/dev/null; then
         echo -e "${GREEN}[Installed]${NC} cc-safe"
-    elif sudo npm install -g cc-safe 2>/dev/null; then
+    elif sudo npm install -g cc-safe@0.1.13 2>/dev/null; then
         echo -e "${GREEN}[Installed]${NC} cc-safe (with sudo)"
     else
-        echo -e "${YELLOW}[Manual install needed]${NC} cc-safe - run: sudo npm install -g cc-safe"
+        echo -e "${YELLOW}[Manual install needed]${NC} cc-safe - run: sudo npm install -g cc-safe@0.1.13"
     fi
 fi
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Summary

`scripts/setup.sh` installs `cc-safe` without a version pin:

```sh
npm install -g cc-safe
sudo npm install -g cc-safe
```

An unpinned global install is a supply-chain risk: if a future version of `cc-safe` on npm introduces a regression, a breaking change, or (in a worst case) a malicious publish, every user who runs `setup.sh` will silently receive it with elevated privileges.

## Fix

Pin all three install invocations to the current known-good release (`0.1.13`):

```sh
npm install -g cc-safe@0.1.13
sudo npm install -g cc-safe@0.1.13
```

When you want to upgrade in the future, bump the version here explicitly so it is a conscious, reviewable change.

> **Note:** This PR addresses only the version-pin (a Low/Medium severity finding). The separate concern of using `sudo` for a global install is a higher-severity topic that deserves its own discussion with the maintainer.

## Test plan

- [ ] Run `bash scripts/setup.sh` and confirm cc-safe installs at 0.1.13
- [ ] Verify `cc-safe --version` reports 0.1.13 after install