### PR TITLE
fix(security): add SHA-256 checksum verification for curl-downloaded context-bar.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -156,6 +156,16 @@ else
         cp "$SCRIPT_DIR/context-bar.sh" "$CLAUDE_DIR/scripts/context-bar.sh"
     else
         curl -sL "$REPO_URL/scripts/context-bar.sh" -o "$CLAUDE_DIR/scripts/context-bar.sh"
+        # Verify integrity before making the downloaded script executable
+        EXPECTED_SHA256="ccc61ad0365a52502659ba1e9c1d4f4677a23b7139a2bd8c3807e18a930d6011"
+        ACTUAL_SHA256=$(command -v sha256sum &>/dev/null && sha256sum "$CLAUDE_DIR/scripts/context-bar.sh" | awk "{print \$1}" || shasum -a 256 "$CLAUDE_DIR/scripts/context-bar.sh" | awk "{print \$1}")
+        if [[ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]]; then
+            echo -e "${RED}[Error]${NC} context-bar.sh checksum mismatch — aborting"
+            echo "  Expected: $EXPECTED_SHA256"
+            echo "  Got:      $ACTUAL_SHA256"
+            rm -f "$CLAUDE_DIR/scripts/context-bar.sh"
+            exit 1
+        fi
     fi
     chmod +x "$CLAUDE_DIR/scripts/context-bar.sh"
     tmp=$(mktemp)


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Summary

`scripts/setup.sh` (remote mode) downloads `context-bar.sh` from the live GitHub branch and immediately marks it executable:

```sh
curl -sL "$REPO_URL/scripts/context-bar.sh" -o "$CLAUDE_DIR/scripts/context-bar.sh"
chmod +x "$CLAUDE_DIR/scripts/context-bar.sh"
```

This script runs on every Claude Code prompt via the `statusLine` hook. If the upstream repo, CDN, or GitHub's raw serving layer were ever tampered with between releases, the modified script would execute silently with user privileges.

## Fix

Add a SHA-256 integrity check between the download and `chmod`:

```sh
EXPECTED_SHA256="ccc61ad0365a52502659ba1e9c1d4f4677a23b7139a2bd8c3807e18a930d6011"
ACTUAL_SHA256=$(command -v sha256sum &>/dev/null && sha256sum ... | awk ... || shasum -a 256 ...)
if [[ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]]; then
    # abort + delete
fi
```

- Works on both **Linux** (`sha256sum`) and **macOS** (`shasum -a 256`)
- If the hash does not match, setup aborts and deletes the downloaded file

**When `context-bar.sh` is intentionally updated**, bump the `EXPECTED_SHA256` value in this file at the same time.

> **Note:** This PR only adds the checksum guard (a Medium-severity improvement). The architectural trade-off of downloading from the live branch versus a tagged release is a separate, higher-level design decision for the maintainer.

## Test plan

- [ ] Run `bash scripts/setup.sh` in remote mode — confirm context-bar.sh installs successfully
- [ ] Temporarily corrupt the downloaded file and confirm setup aborts with the checksum error message
- [ ] Confirm `sha256sum` / `shasum -a 256` both work on the target platform