### PR TITLE
fix: replace hardcoded author path in upgrade-patches command

### DIFF
--- a/.claude/commands/upgrade-patches.md
+++ b/.claude/commands/upgrade-patches.md
@@ -10,4 +10,4 @@ Upgrade system prompt patches to the latest Claude Code version.
 4. If not, follow `system-prompt/UPGRADING.md` to upgrade
 5. Always go through the **full** Final Verification Checklist at the bottom of UPGRADING.md - all three build types (npm, native-linux, native-macos) and all tests in the matrix, not just one. Use tmux for interactive tests like `/context`.
 
-**Container:** Use a dedicated `safeclaw-upgrade` container for all upgrade work. Create it with `cd /Users/yk/Desktop/projects/safeclaw && ./scripts/run.sh -s upgrade -n` if it doesn't exist. Do NOT use other safeclaw containers (e.g. community, work) - they may have specific Claude versions pinned for other purposes.
+**Container:** Use a dedicated `safeclaw-upgrade` container for all upgrade work. Create it with `cd <path-to-safeclaw> && ./scripts/run.sh -s upgrade -n` if it doesn't exist (replace `<path-to-safeclaw>` with the path to your local safeclaw checkout). Do NOT use other safeclaw containers (e.g. community, work) - they may have specific Claude versions pinned for other purposes.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The **Container** section of `.claude/commands/upgrade-patches.md` contains a hardcoded absolute path:

```
cd /Users/yk/Desktop/projects/safeclaw
```

This path is specific to the author's machine. Any other user who runs `/upgrade-patches` will get a path-not-found error at that step, making the command non-functional for them.

## Fix

Replace the hardcoded path with a `<path-to-safeclaw>` placeholder and add an inline note explaining that users should substitute their own checkout path. This matches how documentation typically handles user-specific paths.

## Impact

Without this fix, the `upgrade-patches` command silently breaks for every user other than the author at the Container creation step.