### PR TITLE
fix: add allowed-tools frontmatter to upgrade-patches command

### DIFF
--- a/.claude/commands/upgrade-patches.md
+++ b/.claude/commands/upgrade-patches.md
@@ -1,5 +1,6 @@
 ---
 description: Upgrade system prompt patches to the latest Claude Code version
+allowed-tools: [Bash]
 ---
 
 Upgrade system prompt patches to the latest Claude Code version.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`.claude/commands/upgrade-patches.md` invokes Bash tools (npm, tmux) but its frontmatter does not declare `allowed-tools`. According to the [Claude Code slash command spec](https://docs.anthropic.com/en/docs/claude-code/slash-commands), commands that use tools should list them in `allowed-tools` so that Claude Code knows what permissions to pre-approve.

Without this field, Claude Code may prompt the user for permission on every tool call during the command, or in stricter permission modes may silently refuse to execute the steps.

## Fix

Add `allowed-tools: [Bash]` to the frontmatter, matching the tools the command already uses.

## Impact

The command requires Bash (npm, tmux) to work. Declaring this in frontmatter ensures it runs smoothly without unexpected permission interruptions.