### PR TITLE
fix: pin cc-safe to known-good version in setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -134,12 +134,12 @@ elif command -v cc-safe &> /dev/null; then
     echo -e "${GREEN}[Already installed]${NC} cc-safe"
 else
     echo "[Installing] cc-safe..."
-    if npm install -g cc-safe 2>/dev/null; then
+    if npm install -g cc-safe@0.1.13 2>/dev/null; then
         echo -e "${GREEN}[Installed]${NC} cc-safe"
-    elif sudo npm install -g cc-safe 2>/dev/null; then
+    elif sudo npm install -g cc-safe@0.1.13 2>/dev/null; then
         echo -e "${GREEN}[Installed]${NC} cc-safe (with sudo)"
     else
-        echo -e "${YELLOW}[Manual install needed]${NC} cc-safe - run: sudo npm install -g cc-safe"
+        echo -e "${YELLOW}[Manual install needed]${NC} cc-safe - run: sudo npm install -g cc-safe@0.1.13"
     fi
 fi
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Medium severity)

`scripts/setup.sh` installs `cc-safe` globally without a version pin:

```bash
npm install -g cc-safe
sudo npm install -g cc-safe
```

This means every user who runs setup gets whatever version (or package name collision) is current on npm at that moment. If the `cc-safe` package were ever compromised or typosquatted, the malicious version would be silently installed with elevated privileges.

## Fix

Pin the install to `cc-safe@0.1.13` — the current known-good version at the time of this audit. This makes the install reproducible and auditable. When you intentionally want to upgrade, update the version string in setup.sh alongside any testing.

## Scope

Three lines in the cc-safe install block are updated — the primary `npm install`, the `sudo npm install` fallback, and the manual-install hint message. No logic changes.

## Note

This is a Medium-severity finding. The elevated-privilege path (`sudo npm install`) is the higher-risk variant; even the non-sudo path benefits from pinning for reproducibility.