### PR TITLE
Fix: preserve [CLONED]/[HALF-CLONE] tag in cloned session title

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "dx",
       "source": "./",
       "description": "Developer experience essentials: GitHub Actions debugging, conversation cloning/half-cloning, context handoffs, and Reddit research via Gemini CLI",
-      "version": "0.14.12"
+      "version": "0.14.13"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dx",
   "description": "Developer experience essentials: GitHub Actions debugging, conversation cloning/half-cloning, context handoffs, and Reddit research via Gemini CLI",
-  "version": "0.14.12",
+  "version": "0.14.13",
   "author": {
     "name": "YK",
     "email": "yoyoyosss@wearehackerone.com"

--- a/scripts/clone-conversation.sh
+++ b/scripts/clone-conversation.sh
@@ -299,6 +299,32 @@ clone_conversation() {
     # Touch the file to ensure it appears at the top of claude -r
     touch "$target_file"
 
+    # Override session title so resumed cloned session shows the [CLONED ...] tag.
+    # Claude Code 2.1.x stores titles as custom-title/agent-name records in the
+    # jsonl; it reads the LAST occurrence to determine the resumed session's name.
+    # The awk pass copies source records (with rewritten sessionId) but leaves the
+    # customTitle string alone — without this, cloned session inherits source's
+    # title (e.g. "career-reset-strategy") instead of the [CLONED ...] prefix.
+    local original_title
+    original_title=$(grep '"type":"custom-title"' "$source_file" 2>/dev/null | tail -1 | \
+        grep -oE '"customTitle":"[^"]*"' | head -1 | \
+        sed 's/"customTitle":"//;s/"$//' || true)
+
+    local clone_title
+    if [ -n "$original_title" ]; then
+        clone_title="${clone_tag} ${original_title}"
+    else
+        clone_title="${clone_tag}"
+    fi
+
+    # JSON-escape (backslash first, then double-quote)
+    local clone_title_esc
+    clone_title_esc=$(printf '%s' "$clone_title" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+    echo "{\"type\":\"custom-title\",\"customTitle\":\"${clone_title_esc}\",\"sessionId\":\"${new_session}\"}" >> "$target_file"
+    echo "{\"type\":\"agent-name\",\"agentName\":\"${clone_title_esc}\",\"sessionId\":\"${new_session}\"}" >> "$target_file"
+    log_info "Set session title: ${clone_title}"
+
     # Update history.jsonl
     log_info "Updating history file..."
 

--- a/scripts/half-clone-conversation.sh
+++ b/scripts/half-clone-conversation.sh
@@ -493,6 +493,32 @@ half_clone_conversation() {
     # Touch the file to ensure it appears at the top of claude -r
     touch "$target_file"
 
+    # Override session title so resumed half-cloned session shows the [HALF-CLONE ...] tag.
+    # Claude Code 2.1.x stores titles as custom-title/agent-name records in the
+    # jsonl; it reads the LAST occurrence to determine the resumed session's name.
+    # The awk pass copies source records (with rewritten sessionId) but leaves the
+    # customTitle string alone — without this, half-cloned session inherits source's
+    # title instead of the [HALF-CLONE ...] prefix.
+    local original_title
+    original_title=$(grep '"type":"custom-title"' "$source_file" 2>/dev/null | tail -1 | \
+        grep -oE '"customTitle":"[^"]*"' | head -1 | \
+        sed 's/"customTitle":"//;s/"$//' || true)
+
+    local clone_title
+    if [ -n "$original_title" ]; then
+        clone_title="${clone_tag} ${original_title}"
+    else
+        clone_title="${clone_tag}"
+    fi
+
+    # JSON-escape (backslash first, then double-quote)
+    local clone_title_esc
+    clone_title_esc=$(printf '%s' "$clone_title" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+    echo "{\"type\":\"custom-title\",\"customTitle\":\"${clone_title_esc}\",\"sessionId\":\"${new_session}\"}" >> "$target_file"
+    echo "{\"type\":\"agent-name\",\"agentName\":\"${clone_title_esc}\",\"sessionId\":\"${new_session}\"}" >> "$target_file"
+    log_info "Set session title: ${clone_title}"
+
     # Update history.jsonl
     log_info "Updating history file..."
 


### PR DESCRIPTION
## Summary

Cloned conversations created via `/clone` and `/half-clone` were inheriting the source session's auto-generated kebab-case title (e.g. `career-reset-strategy`) instead of showing the `[CLONED ...]` / `[HALF-CLONE ...]` tag in `claude -r`, terminal tabs, and the TUI title bar.

## Root cause

Claude Code 2.1.x persists session titles as `custom-title` / `agent-name` records embedded in the jsonl. The clone scripts copy these records (with rewritten sessionId) but do not modify the title string itself — Claude Code reads the **last** matching record when resuming, so cloned sessions show the source's name.

## Fix

After writing the cloned/half-cloned jsonl, append a fresh `custom-title` and `agent-name` record with the clone tag prepended (e.g. `[CLONED Apr 27 14:11] career-reset-strategy`). Because Claude Code reads the last occurrence, this overrides the inherited records.

## Files

- `scripts/clone-conversation.sh` — append override records after file write
- `scripts/half-clone-conversation.sh` — same fix, parallel logic
- `.claude-plugin/plugin.json` / `.claude-plugin/marketplace.json` — bump 0.14.12 → 0.14.13

## Test plan

- [ ] Run `/clone` in an active session; verify new jsonl ends with `custom-title` + `agent-name` records containing the `[CLONED ...]` prefix
- [ ] Resume the cloned session via `claude -r`; verify session title shows `[CLONED ...]` prefix
- [ ] Confirm `~/.claude/sessions/<new-pid>.json` has `name` field with `[CLONED ...]` prefix
- [ ] Repeat with `/half-clone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)