### PR TITLE
Fix context bar showing ~10% in worktree/agent sessions

### DIFF
--- a/scripts/context-bar.sh
+++ b/scripts/context-bar.sh
@@ -97,6 +97,14 @@ fi
 # Get transcript path for context calculation and last message feature
 transcript_path=$(echo "$input" | jq -r '.transcript_path // empty')
 
+# Worktree sessions get a new project key with no transcript directory yet.
+# Fall back: search for the session file by ID across all project dirs.
+if [[ -n "$transcript_path" && ! -f "$transcript_path" ]]; then
+    session_file=$(basename "$transcript_path")
+    found=$(find "$HOME/.claude/projects" -maxdepth 2 -name "$session_file" 2>/dev/null | head -1)
+    [[ -n "$found" ]] && transcript_path="$found"
+fi
+
 # Get context window size from JSON (accurate), but calculate tokens from transcript
 # (more accurate than total_input_tokens which excludes system prompt/tools/memory)
 # See: github.com/anthropics/claude-code/issues/13652


### PR DESCRIPTION
## Summary

- Claude Code agents (spawned via the Agent tool or background jobs) run in isolated git worktrees via `EnterWorktree`
- When the CWD switches to the worktree path, Claude Code derives a new project key, so `transcript_path` points to a project directory that doesn't exist yet
- The `-f` check fails and the bar falls back to the 20k baseline (~10%), regardless of actual context usage

## Fix

If `transcript_path` doesn't exist, fall back to searching for the session file by its UUID filename across all project directories under `~/.claude/projects`. The transcript is always written to the original project dir, so the fallback finds it reliably.

## Test plan

- [ ] Open a session normally — context bar reads from `transcript_path` as before (no change)
- [ ] Spawn a Claude agent or enter a worktree mid-session — context bar now finds the transcript via fallback and shows accurate usage instead of ~10%