### PR TITLE
reddit-fetch: make the DDG-hop the primary method, demote curl to last resort

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "dx",
       "source": "./",
       "description": "Developer experience essentials: GitHub Actions debugging, conversation cloning/half-cloning, context handoffs, research (Reddit and Hacker News), and Claude Code version checks",
-      "version": "0.14.20"
+      "version": "0.14.21"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dx",
   "description": "Developer experience essentials: GitHub Actions debugging, conversation cloning/half-cloning, context handoffs, research (Reddit and Hacker News), and Claude Code version checks",
-  "version": "0.14.20",
+  "version": "0.14.21",
   "author": {
     "name": "YK",
     "email": "yoyoyosss@wearehackerone.com"

--- a/skills/reddit-fetch/SKILL.md
+++ b/skills/reddit-fetch/SKILL.md
@@ -1,68 +1,26 @@
 ---
 name: reddit-fetch
-description: Fetch content from Reddit using the curl JSON API. Use when accessing Reddit URLs, researching topics on Reddit, or when Reddit returns 403/blocked errors.
+description: Fetch content from Reddit via its JSON API using a browser session (DuckDuckGo-hop unlock). Use when accessing Reddit URLs, researching topics on Reddit, or when Reddit returns 403/blocked errors.
 ---
 
 # Reddit Fetch
 
-Reddit's public JSON API works by appending `.json` to any Reddit URL. All `curl` examples below need a browser `User-Agent` header - export it once and reuse it:
+Reddit's public JSON API works by appending `.json` to any Reddit URL — but Reddit now hard-blocks automated access. **curl 403s essentially every time (host AND container, regardless of User-Agent), and even a cold Playwright navigation to `reddit.com` hits a `"You've been blocked by network security"` challenge page.** The reliable method is to arrive at Reddit *through a DuckDuckGo result redirect*: that sets a Reddit session cookie which unlocks direct `.json` access for the rest of the browser session.
 
-```bash
-UA="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-```
+## Primary method: the DuckDuckGo-hop unlock
 
-## Endpoints
-
-```bash
-# Listing - swap hot for new/top/rising; for top add &t=day|week|month|year|all
-curl -s -L -H "User-Agent: $UA" "https://old.reddit.com/r/SUBREDDIT/hot.json?limit=15"
-# Post + comments - JSON array where [0]=post, [1]=comment tree
-curl -s -L -H "User-Agent: $UA" "https://old.reddit.com/r/SUBREDDIT/comments/POST_ID.json?limit=20"
-# Search within a subreddit
-curl -s -L -H "User-Agent: $UA" "https://old.reddit.com/r/SUBREDDIT/search.json?q=QUERY&restrict_sr=on&sort=new&limit=15"
-```
-
-## Parsing the JSON
-
-Use jq to extract what you need:
-
-```bash
-# List posts
-curl -s -L -o /tmp/reddit_result.txt -w "%{http_code}" -H "User-Agent: $UA" \
-  'https://old.reddit.com/r/SUBREDDIT/hot.json?limit=15'
-
-jq -r '.data.children[] | .data | "\(.title)\n   \(.score) pts | \(.num_comments) comments | u/\(.author) | id: \(.id)\n"' /tmp/reddit_result.txt
-
-# List comments from a specific post (the [1] element has comments)
-jq -r '.[1].data.children[] | select(.kind == "t1") | .data | "u/\(.author) (\(.score) pts):\n  \(.body[:300])\n"' /tmp/reddit_thread.txt
-```
-
-Key details:
-- Fetch to a temp file (`-o`) then parse - avoids pipe encoding issues; `-w "%{http_code}"` prints the status for debugging empty responses.
-- `-L` follows redirects; single-quote the URL so the shell doesn't eat `&` in query strings.
-- `.body[:300]` truncates long comment bodies (jq 1.7+).
-
-## Rate limiting
-
-Reddit's JSON API rate-limits aggressively:
-
-- **Don't fire parallel requests** - run them sequentially with `sleep 2`/`sleep 3` between each. Fetch one listing, parse it, then fetch threads one at a time.
-- Empty response (0 bytes): wait 3-5s and retry. HTTP 429: back off 10-15s.
-
-## When things get blocked: the DuckDuckGo-hop unlock
-
-Reddit increasingly hard-blocks automated access - **curl (host AND container) 403s, and even a cold Playwright navigation to `reddit.com` hits a `"You've been blocked by network security"` challenge page.** The reliable fix is to arrive at Reddit *through a DuckDuckGo result redirect*: that sets a Reddit session cookie which unlocks direct `.json` access for the rest of the browser session.
-
-**Step 1 - the DDG hop (the unlock).** Do this once per session before any `.json` fetch.
+**Step 1 - the DDG hop.** Do this once per session before any `.json` fetch.
 
 1. `mcp__playwright__browser_navigate` to `https://html.duckduckgo.com/html/?q=site:reddit.com/r/SUBREDDIT+YOUR+QUERY`
 2. Grab the first result's **full href** - it's a DDG redirect that includes a `rut` token (`https://duckduckgo.com/l/?uddg=...&rut=...`). The token is required; navigating to the bare `/l/?uddg=` without it 400s.
    ```js
    () => document.querySelector('.result__a')?.href
    ```
-3. `browser_navigate` to that full redirect href. It lands on the real `www.reddit.com` thread (page title = the post title, **not** "Blocked") and sets the session cookie.
+3. `browser_navigate` to that full redirect href. It lands on a real `www.reddit.com` page (title = the post/subreddit title, **not** "Blocked") and sets the session cookie. The result doesn't have to be the exact thread you want - landing on *any* real Reddit page sets the cookie.
 
-**Step 2 - now direct `.json` works.** For the rest of the session, navigate Playwright straight to any `.json` URL and `JSON.parse(document.body.innerText)` - same shape as curl, so `[0]`=post / `[1]`=comments still applies. Full recency sorting (`sort=new&t=week`) is restored.
+If Playwright errors with `Browser is already in use`, a stale instance is holding the profile - `pkill -f ms-playwright-mcp` (or the profile dir named in the error) and retry.
+
+**Step 2 - direct `.json` now works.** For the rest of the session, navigate Playwright straight to any `.json` URL and `JSON.parse(document.body.innerText)`. Use `www.reddit.com` (not `old.reddit.com`) for browser navigation. Full recency sorting (`sort=new&t=week`) is available.
 
 1. `browser_navigate` to e.g. `https://www.reddit.com/r/SUBREDDIT/search.json?q=QUERY&restrict_sr=on&sort=new&t=week&limit=25`
 2. `browser_evaluate`, **always wrapped in try/catch** (return `document.body.innerText.slice(0,200)` on failure so you can see a challenge page if the session lapsed - just re-do the hop):
@@ -78,11 +36,23 @@ Reddit increasingly hard-blocks automated access - **curl (host AND container) 4
    ```
 3. For a thread, navigate to `.../comments/POST_ID.json?limit=30&sort=top` and parse `data[0]` (post) and `data[1].data.children` (comments).
 
-Use `www.reddit.com` (not `old.reddit.com`) for browser navigation.
+## JSON shapes (same for browser and curl)
 
-### Fallbacks
+```text
+# Listing - swap hot for new/top/rising; for top add &t=day|week|month|year|all
+/r/SUBREDDIT/hot.json?limit=15
+# Post + comments - JSON array where [0]=post, [1]=comment tree
+/r/SUBREDDIT/comments/POST_ID.json?limit=20
+# Search within a subreddit
+/r/SUBREDDIT/search.json?q=QUERY&restrict_sr=on&sort=new&limit=15
+```
 
-- **Fast path, often fails:** plain curl JSON (host or safeclaw container) with a browser `User-Agent` is faster when it works, but usually 403s now (changing the UA doesn't help). Worth one quick try only if you're already shelling out; on 403, go to the DDG hop.
+- Listings: `.data.children[].data` has `title`, `score`, `num_comments`, `author`, `id`.
+- Threads: `[0].data.children[0].data` is the post; `[1].data.children[]` (filter `kind == "t1"`) are comments with `author`, `score`, `body`, and nested `replies` of the same shape.
+- Truncate long comment bodies (e.g. `body.slice(0, 300)` in JS, `.body[:300]` in jq 1.7+) to keep output readable.
+
+## Fallbacks
+
 - **More comments per thread:** load the rendered thread page (after the hop) and scrape the `shreddit` DOM - it returns more comments than `.json?limit=`:
   ```js
   () => ({
@@ -95,3 +65,18 @@ Use `www.reddit.com` (not `old.reddit.com`) for browser navigation.
   })
   ```
 - **No Playwright at all:** use Claude for Chrome to open the thread / `.json` URL and read it off the page.
+- **curl (last resort, expect 403):** direct curl with a browser User-Agent used to work and is faster when it does, but it now gets 403'd essentially always - changing the UA doesn't help. Only worth a single quick try if you're already shelling out and a browser isn't available; on 403, go straight to the DDG hop.
+  ```bash
+  UA="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+  curl -s -L -o /tmp/reddit_result.txt -w "%{http_code}" -H "User-Agent: $UA" \
+    'https://old.reddit.com/r/SUBREDDIT/hot.json?limit=15'
+  jq -r '.data.children[] | .data | "\(.title)\n   \(.score) pts | \(.num_comments) comments | u/\(.author) | id: \(.id)\n"' /tmp/reddit_result.txt
+  ```
+  Fetch to a temp file (`-o`) then parse; `-w "%{http_code}"` prints the status; `-L` follows redirects; single-quote the URL so the shell doesn't eat `&`.
+
+## Rate limiting
+
+Reddit rate-limits aggressively even once you're unblocked:
+
+- **Don't fire parallel requests** - run them sequentially with `sleep 2`/`sleep 3` (or brief pauses between navigations). Fetch one listing, parse it, then fetch threads one at a time.
+- Empty response (0 bytes): wait 3-5s and retry. HTTP 429: back off 10-15s. A challenge page mid-session means the cookie lapsed - re-do the DDG hop.


### PR DESCRIPTION
Direct curl to Reddit's `.json` endpoints now returns 403 essentially every time, regardless of User-Agent (verified again today from a fresh session). The skill still led with curl and treated the DuckDuckGo-hop unlock as a "when things get blocked" fallback — in practice the fallback is the main path.

## Changes

- Restructured the skill to lead with the **DDG-hop browser unlock** as the primary method; the intro now states up front that curl is blocked.
- Kept the endpoint/JSON-shape reference as a shared section (the `.json` payload shape is identical whether fetched via browser or curl).
- Moved curl to the fallback list as a last resort ("only worth a single quick try if a browser isn't available"), keeping the temp-file + `jq` recipe intact.
- Added two field-tested notes: landing on *any* real Reddit page via the DDG redirect sets the session cookie (the first search result doesn't need to be the exact thread), and how to recover from Playwright's `Browser is already in use` error (stale instance holding the profile).
- Updated the frontmatter description to match, and bumped the plugin patch version to 0.14.21 in both manifests per CLAUDE.md.