### PR TITLE
Add article: The missing private GitHub search

### DIFF
--- a/content/the-missing-private-github-search.md
+++ b/content/the-missing-private-github-search.md
@@ -1,0 +1,21 @@
+# The missing private GitHub search
+
+Try to search your own private repos from the command line:
+
+```bash
+gh search code 'insurance' --owner your-username
+```
+
+You'll likely get nothing back, even when you know it's there.
+
+GitHub has two search engines. The good one - the code search that powers github.com/search and does index your private repos - is web-only. The REST API, and therefore the `gh` CLI, still runs on the legacy engine: default branch only, files under 384 KB, only repos with activity in the last year, and in practice it often returns nothing at all for private repos. The new engine has no API.
+
+I ran into this trying to find a note I'd saved in one of my repos, without remembering which one. Across my two accounts I have 228 non-fork repos, 161 of them private, so clicking around wasn't an option. The alternative that works: mirror everything locally and search with ripgrep.
+
+- Shallow clones (`--depth 1`, default branch, forks excluded) of all 228 repos come to 2.8 GB
+- A full-text search over all of it takes about 1 second cold, 11 ms warm
+- A no-change re-sync takes about 15 seconds with 16 parallel fetches, and a timestamp check skips it entirely if the mirror was synced within the last hour
+
+The coverage is the same as GitHub's own search index (default branch tip, no forks), except it actually includes all your private repos, archived ones too.
+
+I turned this into a Claude Code skill, so I can just ask "which repo has X" and it refreshes the mirror and greps. The whole thing is a [~60 line bash script](https://github.com/ykdojo/claude-code-tips/blob/main/skills/private-github-search/private-github-search-sync.sh) plus a [skill file](https://github.com/ykdojo/claude-code-tips/tree/main/skills/private-github-search) - feel free to take a look.

--- a/content/the-missing-private-github-search.md
+++ b/content/the-missing-private-github-search.md
@@ -14,8 +14,8 @@ I ran into this trying to find a note I'd saved in one of my repos, without reme
 
 - Shallow clones (`--depth 1`, default branch, forks excluded) of all 228 repos come to 2.8 GB
 - A full-text search over all of it takes about 1 second cold, 11 ms warm
-- A no-change re-sync takes about 15 seconds with 16 parallel fetches, and a timestamp check skips it entirely if the mirror was synced within the last hour
+- Checking all repos to see if there's anything to update takes about 15 seconds with 16 parallel fetches, and if the mirror already synced within the past hour, the script skips syncing altogether
 
 The coverage is the same as GitHub's own search index (default branch tip, no forks), except it actually includes all your private repos, archived ones too.
 
-I turned this into a Claude Code skill, so I can just ask "which repo has X" and it refreshes the mirror and greps. The whole thing is a [~60 line bash script](https://github.com/ykdojo/claude-code-tips/blob/main/skills/private-github-search/private-github-search-sync.sh) plus a [skill file](https://github.com/ykdojo/claude-code-tips/tree/main/skills/private-github-search) - feel free to take a look.
+I turned this into a Claude Code skill, so I can just ask "which repo has X" and it refreshes the mirror and greps. The whole thing is a [~60 line bash script](https://github.com/ykdojo/claude-code-tips/blob/main/skills/private-github-search/private-github-search-sync.sh) plus a [skill file](https://github.com/ykdojo/claude-code-tips/tree/main/skills/private-github-search).

--- a/content/the-missing-private-github-search.md
+++ b/content/the-missing-private-github-search.md
@@ -15,7 +15,7 @@ Even the web one has a catch: a private repo you've never searched may not be in
 I ran into this trying to find a note I'd saved in one of my repos, without remembering which one. Across my two accounts I have 228 non-fork repos, 161 of them private, so clicking around wasn't an option. The alternative that works: mirror everything locally and search with ripgrep.
 
 - Shallow clones (`--depth 1`, default branch, forks excluded) of all 228 repos come to 2.8 GB
-- A full-text search over all of it takes about 1 second cold, 11 ms warm
+- A full-text search over all of it takes about 1 second the first time, when the files are read from disk, and 11 ms on repeat searches, once the OS has them cached in memory
 - Checking all repos to see if there's anything to update takes about 15 seconds with 16 parallel fetches, and if the mirror already synced within the past hour, the script skips syncing altogether
 
 The coverage is the same as GitHub's own search index (default branch tip, no forks), except it actually includes all your private repos, archived ones too - and there's no indexing lag, so a fresh push is searchable seconds later.

--- a/content/the-missing-private-github-search.md
+++ b/content/the-missing-private-github-search.md
@@ -8,7 +8,9 @@ gh search code 'insurance' --owner your-username
 
 You'll likely get nothing back, even when you know it's there.
 
-GitHub has two search engines. The good one - the code search that powers github.com/search and does index your private repos - is web-only. The REST API, and therefore the `gh` CLI, still runs on the legacy engine: default branch only, files under 384 KB, only repos with activity in the last year, and in practice it often returns nothing at all for private repos. The new engine has no API.
+GitHub has two search engines. The good one - the code search that powers github.com/search and does index your private repos - is web-only. The REST API, and therefore the `gh` CLI, still runs on the legacy engine: default branch only, files under 384 KB, only repos with activity in the last year, and in practice it can return nothing at all for private repos. The new engine has no API.
+
+Even the web one has a catch: a private repo you've never searched may not be in the index at all. When I searched one for the first time, GitHub said it was still indexing the repo and told me to try again in a few minutes.
 
 I ran into this trying to find a note I'd saved in one of my repos, without remembering which one. Across my two accounts I have 228 non-fork repos, 161 of them private, so clicking around wasn't an option. The alternative that works: mirror everything locally and search with ripgrep.
 
@@ -16,6 +18,6 @@ I ran into this trying to find a note I'd saved in one of my repos, without reme
 - A full-text search over all of it takes about 1 second cold, 11 ms warm
 - Checking all repos to see if there's anything to update takes about 15 seconds with 16 parallel fetches, and if the mirror already synced within the past hour, the script skips syncing altogether
 
-The coverage is the same as GitHub's own search index (default branch tip, no forks), except it actually includes all your private repos, archived ones too.
+The coverage is the same as GitHub's own search index (default branch tip, no forks), except it actually includes all your private repos, archived ones too - and there's no indexing lag, so a fresh push is searchable seconds later.
 
 I turned this into a Claude Code skill, so I can just ask "which repo has X" and it refreshes the mirror and greps. The whole thing is a [~60 line bash script](https://github.com/ykdojo/claude-code-tips/blob/main/skills/private-github-search/private-github-search-sync.sh) plus a [skill file](https://github.com/ykdojo/claude-code-tips/tree/main/skills/private-github-search).

--- a/content/the-missing-private-github-search.md
+++ b/content/the-missing-private-github-search.md
@@ -3,7 +3,7 @@
 If you try to search your own private repos from the command line:
 
 ```bash
-gh search code 'insurance' --owner your-username
+gh search code 'todo' --owner your-username
 ```
 
 You'll likely get nothing back, even when you know it's there.

--- a/content/the-missing-private-github-search.md
+++ b/content/the-missing-private-github-search.md
@@ -1,6 +1,6 @@
 # The missing private GitHub search
 
-Try to search your own private repos from the command line:
+If you try to search your own private repos from the command line:
 
 ```bash
 gh search code 'insurance' --owner your-username


### PR DESCRIPTION
Short HN-style article for the content folder.

Angle backed by HN Algolia research: GitHub code search gap posts and ripgrep both have strong track records on HN, and nobody has covered this specific gap (the modern code search that indexes private repos is web-only; the REST API / gh CLI run the legacy engine and usually return nothing for private repos).

Structure: the failing CLI command → why (two search engines) → local mirror + ripgrep with real numbers (228 repos, 161 private, 2.8 GB, 11 ms warm / ~1 s cold, ~15 s sync) → Claude Code skill as a footnote with links.