### PR TITLE
Add quarter-clone: keep only the last quarter of a conversation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
     {
       "name": "dx",
       "source": "./",
-      "description": "Developer experience essentials: GitHub Actions debugging, conversation half-cloning, context handoffs, research (Reddit and Hacker News), private GitHub search, and Claude Code version checks",
-      "version": "0.14.22"
+      "description": "Developer experience essentials: GitHub Actions debugging, conversation half/quarter-cloning, context handoffs, research (Reddit and Hacker News), private GitHub search, and Claude Code version checks",
+      "version": "0.14.23"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dx",
-  "description": "Developer experience essentials: GitHub Actions debugging, conversation half-cloning, context handoffs, research (Reddit and Hacker News), private GitHub search, and Claude Code version checks",
-  "version": "0.14.22",
+  "description": "Developer experience essentials: GitHub Actions debugging, conversation half/quarter-cloning, context handoffs, research (Reddit and Hacker News), private GitHub search, and Claude Code version checks",
+  "version": "0.14.23",
   "author": {
     "name": "YK",
     "email": "yoyoyosss@wearehackerone.com"

--- a/README.md
+++ b/README.md
@@ -575,12 +575,13 @@ This intercepts all `claude` commands, expands `--fs` to `--fork-session`, and p
 
 ### Half-clone to reduce context
 
-When a conversation gets too long, the [half-clone-conversation script](scripts/half-clone-conversation.sh) keeps only the later half. This reduces token usage while preserving your recent work. The first message is tagged with `[HALF-CLONE <timestamp>]` (e.g., `[HALF-CLONE Jan 7 14:30]`).
+When a conversation gets too long, the [half-clone-conversation script](scripts/half-clone-conversation.sh) keeps only the later half. This reduces token usage while preserving your recent work. The first message is tagged with `[HALF-CLONE <timestamp>]` (e.g., `[HALF-CLONE Jan 7 14:30]`). There's also a quarter-clone variant (`--quarter`, or the `quarter-clone` skill) that keeps only the last quarter, tagged with `[QUARTER-CLONE <timestamp>]` - useful when even half is too much.
 
-To set it up manually, symlink both files:
+To set it up manually, symlink the script and skills:
 ```bash
 ln -s /path/to/this/repo/scripts/half-clone-conversation.sh ~/.claude/scripts/half-clone-conversation.sh
 ln -s /path/to/this/repo/skills/half-clone ~/.claude/skills/half-clone
+ln -s /path/to/this/repo/skills/quarter-clone ~/.claude/skills/quarter-clone
 ```
 
 Or install via the [dx plugin](#tip-43-install-the-dx-plugin) - no symlinks needed.
@@ -902,6 +903,7 @@ This repo is also a Claude Code plugin called `dx` (developer experience). It bu
 | `/dx:gha <url>` | Analyze GitHub Actions failures (Tip 27) |
 | `/dx:handoff` | Create handoff documents for context continuity (Tip 8) |
 | `/dx:half-clone` | Half-clone to reduce context (Tip 21) |
+| `/dx:quarter-clone` | Quarter-clone to reduce context even more (Tip 21) |
 | `/dx:reddit-fetch` | Fetch Reddit content via Reddit's JSON API |
 | `/dx:review-claudemd` | Review conversations to improve CLAUDE.md files (Tip 28) |
 | `/dx:hn-summarize` | Summarize Hacker News top stories, articles, and comment threads |

--- a/scripts/half-clone-conversation.sh
+++ b/scripts/half-clone-conversation.sh
@@ -33,6 +33,7 @@ KEEP_DENOM=2
 CLONE_LABEL="HALF-CLONE"
 MODE_NAME="half-clone"
 KEPT_DESC="later half"
+FALLBACK_DISPLAY="[Half-cloned conversation]"
 
 # Colors for output
 RED='\033[0;31m'
@@ -524,14 +525,14 @@ half_clone_conversation() {
     display_text=$(tail -n +"$((skip_count + 1))" "$source_file" | filter_clean_user_msgs | \
         grep -oE '"content":"[^"]*"' | head -1 | \
         LC_ALL=C sed 's/"content":"//;s/"$//' | \
-        head -c 200 || echo "[Cloned conversation]")
+        head -c 200 || echo "$FALLBACK_DISPLAY")
 
     if [ -z "$display_text" ]; then
         # Try array format
         display_text=$(tail -n +"$((skip_count + 1))" "$source_file" | filter_clean_user_msgs | \
             grep -oE '"text":"[^"]*"' | head -1 | \
             LC_ALL=C sed 's/"text":"//;s/"$//' | \
-            head -c 200 || echo "[Cloned conversation]")
+            head -c 200 || echo "$FALLBACK_DISPLAY")
     fi
 
     display_text="${clone_tag} ${display_text}"
@@ -579,6 +580,7 @@ while [ $# -gt 0 ]; do
             CLONE_LABEL="QUARTER-CLONE"
             MODE_NAME="quarter-clone"
             KEPT_DESC="last quarter"
+            FALLBACK_DISPLAY="[Quarter-cloned conversation]"
             shift
             ;;
         *)

--- a/scripts/half-clone-conversation.sh
+++ b/scripts/half-clone-conversation.sh
@@ -1,22 +1,24 @@
 #!/usr/bin/env bash
 #
-# half-clone-conversation.sh - Clone the later half of a Claude Code conversation
+# half-clone-conversation.sh - Clone the later half (or quarter) of a Claude Code conversation
 #
 # Pure bash implementation - no Python/Node dependencies.
 # Works on macOS (bash 3.2+) and Linux.
 #
 # Usage:
-#   half-clone-conversation.sh <session-id> [project-path]
+#   half-clone-conversation.sh [--quarter] <session-id> [project-path]
 #
 # Arguments:
+#   --quarter     Keep only the last quarter instead of the later half
 #   session-id    The UUID of the conversation to clone (required)
 #   project-path  The project path (default: current directory)
 #
 # Example:
 #   half-clone-conversation.sh d96c899d-7501-4e81-a31b-e0095bb3b501
+#   half-clone-conversation.sh --quarter d96c899d-7501-4e81-a31b-e0095bb3b501
 #   half-clone-conversation.sh d96c899d-7501-4e81-a31b-e0095bb3b501 /home/user/myproject
 #
-# After cloning, use 'claude -r' to see both the original and half-cloned conversation.
+# After cloning, use 'claude -r' to see both the original and cloned conversation.
 #
 
 set -euo pipefail
@@ -25,6 +27,12 @@ CLAUDE_DIR="${HOME}/.claude"
 PROJECTS_DIR="${CLAUDE_DIR}/projects"
 HISTORY_FILE="${CLAUDE_DIR}/history.jsonl"
 TODOS_DIR="${CLAUDE_DIR}/todos"
+
+# Clone mode - defaults to half; --quarter switches to keeping the last quarter
+KEEP_DENOM=2
+CLONE_LABEL="HALF-CLONE"
+MODE_NAME="half-clone"
+KEPT_DESC="later half"
 
 # Colors for output
 RED='\033[0;31m'
@@ -39,9 +47,10 @@ log_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 
 usage() {
-    echo "Usage: $0 <session-id> [project-path]"
+    echo "Usage: $0 [--quarter] <session-id> [project-path]"
     echo ""
     echo "Arguments:"
+    echo "  --quarter     Keep only the last quarter instead of the later half"
     echo "  session-id    The UUID of the conversation to clone (required)"
     echo "  project-path  The project path (default: current directory)"
     exit 1
@@ -184,7 +193,7 @@ half_clone_conversation() {
     # Generate timestamp for clone tag (e.g., "Jan 7 14:30")
     local clone_timestamp
     clone_timestamp=$(date "+%b %-d %H:%M")
-    local clone_tag="[HALF-CLONE ${clone_timestamp}]"
+    local clone_tag="[${CLONE_LABEL} ${clone_timestamp}]"
 
     # Find source file
     local source_file
@@ -215,13 +224,14 @@ half_clone_conversation() {
     log_info "Total clean user messages in conversation: $total_clean_user_messages"
 
     if [ "$total_clean_user_messages" -lt 2 ]; then
-        log_error "Conversation has fewer than 2 clean user messages, nothing to half-clone"
+        log_error "Conversation has fewer than 2 clean user messages, nothing to ${MODE_NAME}"
         exit 1
     fi
 
-    # Calculate which clean user message to start from (halfway point)
+    # Calculate which clean user message to start from
+    # (half: skip 1/2; quarter: skip 3/4)
     local skip_clean_count
-    skip_clean_count=$((total_clean_user_messages / 2))
+    skip_clean_count=$((total_clean_user_messages * (KEEP_DENOM - 1) / KEEP_DENOM))
     local keep_clean_count
     keep_clean_count=$((total_clean_user_messages - skip_clean_count))
 
@@ -249,7 +259,7 @@ half_clone_conversation() {
     local target_file="${project_dir}/${new_session}.jsonl"
 
     mkdir -p "$project_dir"
-    log_info "Half-cloning conversation to: $target_file"
+    log_info "Cloning ${KEPT_DESC} of conversation to: $target_file"
 
     # OPTIMIZED First pass: find if last clean user message is a clone/half-clone command
     # Use grep -n to find all user messages in a single pass, then filter
@@ -268,7 +278,7 @@ half_clone_conversation() {
         last_clean_user_line=$(echo "$last_line_info" | cut -d: -f1)
 
         # Check if it's a clone command
-        if echo "$last_line_info" | grep -qE '<command-message>(dx:)?clone</command-message>|<command-message>(dx:)?half-clone</command-message>' 2>/dev/null; then
+        if echo "$last_line_info" | grep -qE '<command-message>(dx:)?(half-clone|quarter-clone|clone)</command-message>' 2>/dev/null; then
             last_clone_cmd_line=$last_clean_user_line
         fi
     fi
@@ -304,7 +314,8 @@ half_clone_conversation() {
          -v new_session="$new_session" \
          -v clone_tag="$clone_tag" \
          -v uuid_file="$uuid_file" \
-         -v marker_uuid="$marker_uuid" '
+         -v marker_uuid="$marker_uuid" \
+         -v keep_denom="$KEEP_DENOM" '
     BEGIN {
         first_message = 1
         first_user = 1
@@ -387,14 +398,14 @@ half_clone_conversation() {
         return ""
     }
 
-    function halve_number(line, field,    pattern, num, halved) {
+    function divide_number(line, field,    pattern, num, divided) {
         pattern = "\"" field "\":[0-9]+"
         if (match(line, pattern)) {
             match_str = substr(line, RSTART, RLENGTH)
             gsub("\"" field "\":", "", match_str)
             num = int(match_str)
-            halved = int(num / 2)
-            gsub("\"" field "\":" num, "\"" field "\":" halved, line)
+            divided = int(num / keep_denom)
+            gsub("\"" field "\":" num, "\"" field "\":" divided, line)
         }
         return line
     }
@@ -466,10 +477,10 @@ half_clone_conversation() {
             }
         }
 
-        # Halve token counts
-        line = halve_number(line, "input_tokens")
-        line = halve_number(line, "cache_read_input_tokens")
-        line = halve_number(line, "cache_creation_input_tokens")
+        # Scale down token counts (divide by 2 for half, 4 for quarter)
+        line = divide_number(line, "input_tokens")
+        line = divide_number(line, "cache_read_input_tokens")
+        line = divide_number(line, "cache_creation_input_tokens")
 
         # Strip thinking blocks
         line = strip_thinking(line)
@@ -492,7 +503,7 @@ half_clone_conversation() {
     ref_uuid=$(generate_uuid)
     local ref_timestamp
     ref_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-    local ref_text="The half-clone is complete. This conversation now only contains the later half of the original - earlier context was removed to free up space. Just continue working from where you left off. Original session: \`${source_session}\` at: ${source_file}"
+    local ref_text="The ${MODE_NAME} is complete. This conversation now only contains the ${KEPT_DESC} of the original - earlier context was removed to free up space. Just continue working from where you left off. Original session: \`${source_session}\` at: ${source_file}"
     echo "{\"parentUuid\":\"${last_uuid}\",\"isSidechain\":false,\"userType\":\"external\",\"sessionId\":\"${new_session}\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"${ref_text}\"}]},\"uuid\":\"${ref_uuid}\",\"timestamp\":\"${ref_timestamp}\",\"isMeta\":true}" >> "$target_file"
 
     local output_line_count
@@ -513,14 +524,14 @@ half_clone_conversation() {
     display_text=$(tail -n +"$((skip_count + 1))" "$source_file" | filter_clean_user_msgs | \
         grep -oE '"content":"[^"]*"' | head -1 | \
         LC_ALL=C sed 's/"content":"//;s/"$//' | \
-        head -c 200 || echo "[Half-cloned conversation]")
+        head -c 200 || echo "[Cloned conversation]")
 
     if [ -z "$display_text" ]; then
         # Try array format
         display_text=$(tail -n +"$((skip_count + 1))" "$source_file" | filter_clean_user_msgs | \
             grep -oE '"text":"[^"]*"' | head -1 | \
             LC_ALL=C sed 's/"text":"//;s/"$//' | \
-            head -c 200 || echo "[Half-cloned conversation]")
+            head -c 200 || echo "[Cloned conversation]")
     fi
 
     display_text="${clone_tag} ${display_text}"
@@ -540,16 +551,16 @@ half_clone_conversation() {
     echo "{\"display\":\"${display_text}\",\"pastedContents\":{},\"timestamp\":${timestamp},\"project\":\"${project_path}\",\"sessionId\":\"${new_session}\"}" >> "$HISTORY_FILE"
     log_success "History entry added"
 
-    # Note: We don't copy todos for half-clone since the context is truncated
+    # Note: We don't copy todos since the context is truncated
 
-    log_success "Conversation half-cloned successfully!"
+    log_success "Conversation ${MODE_NAME}d successfully!"
     echo ""
     echo "Original session: $source_session"
     echo "New session:      $new_session"
     echo "Project:          $project_path"
     echo "Clean user msgs:  $keep_clean_count of $total_clean_user_messages (skipped first $skip_clean_count)"
     echo ""
-    echo "To resume the half-cloned conversation, use:"
+    echo "To resume the cloned conversation, use:"
     echo "  claude -r"
     echo ""
     echo "Then select the conversation marked with ${clone_tag}"
@@ -557,10 +568,24 @@ half_clone_conversation() {
 
 # Main
 PREVIEW_MODE=false
-if [ "${1:-}" = "--preview" ]; then
-    PREVIEW_MODE=true
-    shift
-fi
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --preview)
+            PREVIEW_MODE=true
+            shift
+            ;;
+        --quarter)
+            KEEP_DENOM=4
+            CLONE_LABEL="QUARTER-CLONE"
+            MODE_NAME="quarter-clone"
+            KEPT_DESC="last quarter"
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
 if [ $# -lt 1 ]; then
     usage

--- a/scripts/test-half-clone.sh
+++ b/scripts/test-half-clone.sh
@@ -93,8 +93,9 @@ create_test_conversation() {
 
 run_half_clone() {
     local session_id="$1"
-    # Override HOME to use test directory
-    HOME="$TEST_DIR" "$HALF_CLONE_SCRIPT" "$session_id" "$TEST_PROJECT_PATH" 2>&1
+    shift
+    # Override HOME to use test directory; extra flags (e.g. --quarter) go before the session id
+    HOME="$TEST_DIR" "$HALF_CLONE_SCRIPT" "$@" "$session_id" "$TEST_PROJECT_PATH" 2>&1
 }
 
 count_messages() {
@@ -510,6 +511,169 @@ test_session_config_lines_stripped() {
     fi
 }
 
+# Test 13: Quarter mode - 8 messages (4 clean user): skip 3, keep 1
+# Output: marker(1) + kept lines 7-8(2) + reference(1) = 4
+test_quarter_eight_messages() {
+    log_test "Quarter: 8 messages (4 clean user): should produce 1 marker + 2 kept + 1 reference = 4"
+
+    local session_id
+    session_id=$(create_test_conversation 8)
+    local output
+    output=$(run_half_clone "$session_id" --quarter)
+
+    local new_session
+    new_session=$(get_new_session_from_output "$output")
+    local new_file="${TEST_PROJECTS_DIR}/${TEST_PROJECT_DIRNAME}/${new_session}.jsonl"
+
+    if [ ! -f "$new_file" ]; then
+        log_fail "Output file not created"
+        return
+    fi
+
+    local count
+    count=$(count_messages "$new_file")
+    if [ "$count" -eq 4 ]; then
+        log_pass "Kept 4 messages (marker + 2 kept + reference)"
+    else
+        log_fail "Expected 4 messages, got $count"
+    fi
+
+    # The kept user message should be the LAST user message (message 7)
+    if grep -q "User message 7" "$new_file"; then
+        log_pass "Kept the last quarter (User message 7 present)"
+    else
+        log_fail "User message 7 not found in quarter clone"
+    fi
+    ((++TESTS_RUN)) || true
+}
+
+# Test 14: Quarter mode - [QUARTER-CLONE <timestamp>] tag in file and history
+test_quarter_tag() {
+    log_test "Quarter: [QUARTER-CLONE <timestamp>] tag should be in first user message and history"
+
+    local session_id
+    session_id=$(create_test_conversation 8)
+    local output
+    output=$(run_half_clone "$session_id" --quarter)
+
+    local new_session
+    new_session=$(get_new_session_from_output "$output")
+    local new_file="${TEST_PROJECTS_DIR}/${TEST_PROJECT_DIRNAME}/${new_session}.jsonl"
+
+    if grep -qE '\[QUARTER-CLONE [A-Z][a-z]+ [0-9]+ [0-9]+:[0-9]+\]' "$new_file"; then
+        log_pass "[QUARTER-CLONE <timestamp>] tag found in clone"
+    else
+        log_fail "[QUARTER-CLONE <timestamp>] tag not found in clone"
+    fi
+
+    ((++TESTS_RUN)) || true
+    if grep -qE '\[QUARTER-CLONE [A-Z][a-z]+ [0-9]+ [0-9]+:[0-9]+\]' "${TEST_CLAUDE_DIR}/history.jsonl"; then
+        log_pass "[QUARTER-CLONE <timestamp>] tag found in history"
+    else
+        log_fail "[QUARTER-CLONE <timestamp>] tag not found in history"
+    fi
+}
+
+# Test 15: Quarter mode - token counts divided by 4
+test_quarter_token_division() {
+    log_test "Quarter: token counts should be divided by 4"
+
+    local session_id
+    session_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    local conv_file="${TEST_PROJECTS_DIR}/${TEST_PROJECT_DIRNAME}/${session_id}.jsonl"
+
+    local uuid1 uuid2 uuid3 uuid4
+    uuid1=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    uuid2=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    uuid3=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    uuid4=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+    # 4 messages (2 clean user). Quarter skips 1, keeps 1 - lines 3-4 are kept.
+    # The kept assistant message carries usage numbers divisible by 4.
+    {
+        echo "{\"parentUuid\":null,\"sessionId\":\"${session_id}\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"Question 1\"},\"uuid\":\"${uuid1}\",\"timestamp\":\"2025-01-01T00:00:00.000Z\"}"
+        echo "{\"parentUuid\":\"${uuid1}\",\"sessionId\":\"${session_id}\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Answer 1\"}],\"usage\":{\"input_tokens\":100,\"cache_read_input_tokens\":200,\"cache_creation_input_tokens\":300}},\"uuid\":\"${uuid2}\",\"timestamp\":\"2025-01-01T00:00:00.000Z\"}"
+        echo "{\"parentUuid\":\"${uuid2}\",\"sessionId\":\"${session_id}\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"Question 2\"},\"uuid\":\"${uuid3}\",\"timestamp\":\"2025-01-01T00:00:00.000Z\"}"
+        echo "{\"parentUuid\":\"${uuid3}\",\"sessionId\":\"${session_id}\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Answer 2\"}],\"usage\":{\"input_tokens\":400,\"cache_read_input_tokens\":800,\"cache_creation_input_tokens\":1200}},\"uuid\":\"${uuid4}\",\"timestamp\":\"2025-01-01T00:00:00.000Z\"}"
+    } > "$conv_file"
+
+    local output
+    output=$(run_half_clone "$session_id" --quarter)
+
+    local new_session
+    new_session=$(get_new_session_from_output "$output")
+    local new_file="${TEST_PROJECTS_DIR}/${TEST_PROJECT_DIRNAME}/${new_session}.jsonl"
+
+    if grep -q '"input_tokens":100' "$new_file" && \
+       grep -q '"cache_read_input_tokens":200' "$new_file" && \
+       grep -q '"cache_creation_input_tokens":300' "$new_file"; then
+        log_pass "Token counts divided by 4 (400->100, 800->200, 1200->300)"
+    else
+        log_fail "Token counts not divided by 4"
+        grep -o '"usage":{[^}]*}' "$new_file" || true
+    fi
+}
+
+# Test 16: Half mode still halves token counts (regression check for divide_number)
+test_half_token_division() {
+    log_test "Half: token counts should still be divided by 2"
+
+    local session_id
+    session_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    local conv_file="${TEST_PROJECTS_DIR}/${TEST_PROJECT_DIRNAME}/${session_id}.jsonl"
+
+    local uuid1 uuid2 uuid3 uuid4
+    uuid1=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    uuid2=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    uuid3=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    uuid4=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+    {
+        echo "{\"parentUuid\":null,\"sessionId\":\"${session_id}\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"Question 1\"},\"uuid\":\"${uuid1}\",\"timestamp\":\"2025-01-01T00:00:00.000Z\"}"
+        echo "{\"parentUuid\":\"${uuid1}\",\"sessionId\":\"${session_id}\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Answer 1\"}]},\"uuid\":\"${uuid2}\",\"timestamp\":\"2025-01-01T00:00:00.000Z\"}"
+        echo "{\"parentUuid\":\"${uuid2}\",\"sessionId\":\"${session_id}\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"Question 2\"},\"uuid\":\"${uuid3}\",\"timestamp\":\"2025-01-01T00:00:00.000Z\"}"
+        echo "{\"parentUuid\":\"${uuid3}\",\"sessionId\":\"${session_id}\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Answer 2\"}],\"usage\":{\"input_tokens\":400,\"cache_read_input_tokens\":800,\"cache_creation_input_tokens\":1200}},\"uuid\":\"${uuid4}\",\"timestamp\":\"2025-01-01T00:00:00.000Z\"}"
+    } > "$conv_file"
+
+    local output
+    output=$(run_half_clone "$session_id")
+
+    local new_session
+    new_session=$(get_new_session_from_output "$output")
+    local new_file="${TEST_PROJECTS_DIR}/${TEST_PROJECT_DIRNAME}/${new_session}.jsonl"
+
+    if grep -q '"input_tokens":200' "$new_file" && \
+       grep -q '"cache_read_input_tokens":400' "$new_file" && \
+       grep -q '"cache_creation_input_tokens":600' "$new_file"; then
+        log_pass "Token counts divided by 2 (400->200, 800->400, 1200->600)"
+    else
+        log_fail "Token counts not divided by 2"
+        grep -o '"usage":{[^}]*}' "$new_file" || true
+    fi
+}
+
+# Test 17: Quarter mode - minimum conversation (2 clean user msgs) still works
+test_quarter_minimum_messages() {
+    log_test "Quarter: 4 messages (2 clean user): should skip 1, keep 1"
+
+    local session_id
+    session_id=$(create_test_conversation 4)
+    local output
+    output=$(run_half_clone "$session_id" --quarter)
+
+    local new_session
+    new_session=$(get_new_session_from_output "$output")
+    local new_file="${TEST_PROJECTS_DIR}/${TEST_PROJECT_DIRNAME}/${new_session}.jsonl"
+
+    local count
+    count=$(count_messages "$new_file")
+    if [ "$count" -eq 4 ]; then
+        log_pass "Kept 4 messages (marker + 2 kept + reference)"
+    else
+        log_fail "Expected 4 messages, got $count"
+    fi
+}
+
 # Main
 main() {
     echo "================================"
@@ -537,6 +701,11 @@ main() {
     test_thinking_blocks_stripped
     test_progress_with_nested_user_type
     test_session_config_lines_stripped
+    test_quarter_eight_messages
+    test_quarter_tag
+    test_quarter_token_division
+    test_half_token_division
+    test_quarter_minimum_messages
 
     echo ""
     echo "================================"

--- a/skills/quarter-clone/SKILL.md
+++ b/skills/quarter-clone/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: quarter-clone
+description: Clone the last quarter of the current conversation, discarding earlier context to reduce token usage while preserving recent work.
+---
+
+Clone the last quarter of the current conversation, discarding earlier context to reduce token usage while preserving recent work.
+
+Steps:
+1. Get the current session ID and project path: `tail -1 ~/.claude/history.jsonl | jq -r '[.sessionId, .project] | @tsv'`
+2. Find half-clone-conversation.sh with bash: `find ~/.claude -name "half-clone-conversation.sh" 2>/dev/null | sort -V | tail -1`
+   - This finds the script whether installed via plugin or manual symlink
+   - Uses version sort to prefer the latest version if multiple exist
+   - The same script handles both half and quarter cloning; `--quarter` selects quarter mode
+3. Preview the conversation to verify the session ID: `<script-path> --preview <session-id> <project-path>`
+   - Check that the first and last messages match the current conversation
+4. Run the clone: `<script-path> --quarter <session-id> <project-path>`
+   - Always pass the project path from the history entry, not the current working directory
+5. The script prints the new session ID (the `New session: <id>` line). Give the user the exact command to resume it directly, no picker needed:
+   ```
+   claude --resume <new-session-id>
+   ```
+   The script automatically appends a reference to the original conversation at the end of the cloned file. (The new session is also marked `[QUARTER-CLONE <timestamp>]`, e.g. `[QUARTER-CLONE Jan 7 14:30]`, so `claude -r` and picking it works as a fallback.)


### PR DESCRIPTION
Adds a quarter-clone option for when even half-clone keeps too much context.

## What changed

- `scripts/half-clone-conversation.sh`: new `--quarter` flag. It skips the first 3/4 of clean user messages instead of 1/2, tags the clone `[QUARTER-CLONE <timestamp>]`, and divides token counts by 4. No separate script - half and quarter share the same code path, selected by flag.
- `skills/quarter-clone/SKILL.md`: new skill, mirrors half-clone but passes `--quarter`.
- `scripts/test-half-clone.sh`: 5 new tests (quarter message counts, quarter tag in clone and history, token division by 4, half token division regression, quarter minimum-size conversation). 19/19 total.
- Plugin version bumped to 0.14.23; README tip 21 and the plugin skill table mention quarter-clone.

## How it was verified

- Unit tests: 19/19 pass on macOS and on Linux (safeclaw container).
- Byte-identical half mode: ran the old script (from main) and the new one on the same inputs with deterministic shims for `uuidgen`, `hexdump`, and `date` - one real 8 MB / 1175-line conversation and one synthetic conversation covering thinking blocks, tool_results, usage tokens, session-config lines, and a trailing clone command. Clone file and history.jsonl are byte-identical in half mode; only informational stdout wording differs.
- End-to-end quarter mode: quarter-cloned a real conversation, validated every line is valid JSON, session IDs remapped, no thinking blocks, no dangling parents except the by-design tool_result orphan, then resumed the clone with `claude --resume -p` and got a normal response (no API 400).