### PR TITLE
Fix stat mtime detection on Linux (sync-age display broken)

### DIFF
--- a/scripts/context-bar.sh
+++ b/scripts/context-bar.sh
@@ -45,7 +45,7 @@ if [[ -n "$cwd" && -d "$cwd" ]]; then
             fetch_head="$cwd/.git/FETCH_HEAD"
             fetch_ago=""
             if [[ -f "$fetch_head" ]]; then
-                fetch_time=$(stat -f %m "$fetch_head" 2>/dev/null || stat -c %Y "$fetch_head" 2>/dev/null)
+                fetch_time=$(stat -c %Y "$fetch_head" 2>/dev/null || stat -f %m "$fetch_head" 2>/dev/null)
                 if [[ -n "$fetch_time" ]]; then
                     now=$(date +%s)
                     diff=$((now - fetch_time))


### PR DESCRIPTION
On GNU/Linux, `stat -f` is a **valid** flag (it prints filesystem status), so it succeeds instead of erroring — the `|| stat -c %Y` fallback never fires. `$fetch_time` then captures multi-line filesystem output, `$((now - fetch_time))` throws `syntax error in expression`, and the git sync-age (`synced Nm ago`) never renders.

**Fix:** try the GNU form (`-c %Y`) first, fall back to BSD/macOS (`-f %m`):

```diff
-fetch_time=$(stat -f %m "$fetch_head" 2>/dev/null || stat -c %Y "$fetch_head" 2>/dev/null)
+fetch_time=$(stat -c %Y "$fetch_head" 2>/dev/null || stat -f %m "$fetch_head" 2>/dev/null)
```

Correct on both platforms: Linux hits `-c` first; macOS errors on `-c` (BSD stat has no `-c`) and falls through to `-f %m`. One-line change, no behavior change on macOS.