### PR TITLE
Tip 33: it's the artifact card that opens in the app, not the link

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ If you're building a front-end app with HTML, CSS, and JavaScript, an artifact i
 
 The nice thing about it is that it's gated behind your Anthropic login: a new artifact is only visible to you, so you can check it privately or share it privately.
 
-It works great from your phone as well. You can tap the link in the Claude mobile app and it opens directly there in the app.
+It works great from your phone as well. In the Claude mobile app, tap the artifact card and it opens right there in the app.
 
 One thing to keep in mind: an artifact is a single self-contained page with no backend, and external requests are blocked - so if your HTML pulls a library from a CDN, bundle it into the file first.
 


### PR DESCRIPTION
Tapping the artifact card in the Claude mobile app opens it in-app; tapping the plain claude.ai link below it still needs a copy-paste into a browser. The previous wording didn't make that distinction.