### PR TITLE
Tip 31: document how to make auto mode the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ Auto mode lets Claude decide whether a command is safe to run in context, instea
 
 The main thing it fixes is mindless approving. When a command is too long to read carefully, or you're getting tired, you end up approving things without really thinking about them. Auto mode takes that pressure off, so I think it's a good default.
 
-To make it the default so every new session starts in it, add this to `~/.claude/settings.json`:
+To make it the default, add this to `~/.claude/settings.json`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -716,6 +716,16 @@ Auto mode lets Claude decide whether a command is safe to run in context, instea
 
 The main thing it fixes is mindless approving. When a command is too long to read carefully, or you're getting tired, you end up approving things without really thinking about them. Auto mode takes that pressure off, so I think it's a good default.
 
+To make it the default so every new session starts in it, add this to `~/.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "defaultMode": "auto"
+  }
+}
+```
+
 If you still want to be careful, you can always approve things manually without auto mode. And if you want to give it complete independence, you can [run Claude Code in a container with `--dangerously-skip-permissions`](#tip-19-isolated-environments-for-long-running-risky-tasks).
 
 ## Tip 32: Control Claude Code from your phone


### PR DESCRIPTION
Adds the `permissions.defaultMode` settings snippet to Tip 31 so readers know how to start every session in auto mode.